### PR TITLE
Minor bugfixes, add `_strip_end`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [v0.0.3] 2020-01-10
+
+* Added missing `black` and `isort` requirements - @jessebraham
+* Added `_strip_end` as an option for patching - @jessebraham
+
 ## [v0.0.2] 2019-08-20
 
 * Import the current `stm32-rs/scripts/svdpatch.py` instead of an old one
@@ -11,4 +16,3 @@
 * Initial release, importing from `stm32-rs/scripts/svdpatch.py`
 * Added `click` CLI, to call as `svd patch <yaml-file>`
 * Added packaging
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,3 @@
-flit
+black==19.10b0
+flit==2.1.0
+isort==4.3.21

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-black==19.10b0
-flit==2.1.0
-isort==4.3.21
+black
+flit
+isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author = "Adam Greig"
 author-email = "adam@adamgreig.com"
 maintainer = "Nicolas Stalder"
 maintainer-email = "n@stalder.io"
-home-page = "https://github.com/nickray/svdtools"
+home-page = "https://github.com/stm32-rs/svdtools"
 requires-python = ">=3.6"
 requires = [
   "click >= 7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit"]
+requires = ["black", "flit", "isort"]
 build-backend = "flit.buildapi"
 
 [tool.flit.metadata]

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -504,7 +504,7 @@ class Peripheral:
             name = nametag.text
 
             if strip_end and name.endswith(substr):
-                nametag.text = name[: len(name) - len(substr)]
+                nametag.text = name[: len(substr)]
             elif name.startswith(substr):
                 nametag.text = name[len(substr) :]
 
@@ -513,7 +513,7 @@ class Peripheral:
                 dname = dnametag.text
 
                 if strip_end and dname.endswith(substr):
-                    dnametag.text = dname[: len(dname) - len(substr)]
+                    dnametag.text = dname[: len(substr)]
                 elif dname.startswith(substr):
                     dnametag.text = dname[len(substr) :]
 

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -509,9 +509,11 @@ class Peripheral:
             if name.startswith(prefix):
                 nametag.text = name[len(prefix) :]
                 dnametag = rtag.find("displayName")
-                dname = dnametag.text
-                if dname.startswith(prefix):
-                    dnametag.text = dname[len(prefix) :]
+                # not all SVD files provide display name tags
+                if dnametag is not None:
+                    dname = dnametag.text
+                    if dname.startswith(prefix):
+                        dnametag.text = dname[len(prefix) :]
 
     def collect_in_array(self, rspec, rmod):
         """Collect same registers in peripheral into register array."""

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -5,7 +5,6 @@ Copyright 2017-2019 Adam Greig.
 Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
 """
 
-import argparse
 import copy
 import os.path
 import xml.etree.ElementTree as ET
@@ -42,14 +41,6 @@ def dict_constructor(loader, node):
 
 _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
 yaml.add_constructor(_mapping_tag, dict_constructor, yaml.SafeLoader)
-
-
-def parseargs():
-    """Parse our command line arguments, returns a Namespace of results."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("yaml", help="Path to YAML file to load")
-    args = parser.parse_args()
-    return args
 
 
 def matchname(name, spec):
@@ -384,7 +375,9 @@ class Device:
                     p.modify_register(rspec, rmod)
             # Handle strips
             for prefix in peripheral.get("_strip", []):
-                p.strip_prefix(prefix)
+                p.strip(prefix)
+            for suffix in peripheral.get("_strip_end", []):
+                p.strip(suffix, strip_end=True)
             # Handle additions
             for rname in peripheral.get("_add", {}):
                 radd = peripheral["_add"][rname]
@@ -501,19 +494,28 @@ class Peripheral:
         for rtag in list(self.iter_registers(rspec)):
             self.ptag.find("registers").remove(rtag)
 
-    def strip_prefix(self, prefix):
-        """Delete prefix in register names inside ptag."""
+    def strip(self, substr, strip_end=False):
+        """
+        Delete substring from register names inside ptag. Strips from the
+        beginning of the name by default.
+        """
         for rtag in self.ptag.iter("register"):
             nametag = rtag.find("name")
             name = nametag.text
-            if name.startswith(prefix):
-                nametag.text = name[len(prefix) :]
-                dnametag = rtag.find("displayName")
-                # not all SVD files provide display name tags
-                if dnametag is not None:
-                    dname = dnametag.text
-                    if dname.startswith(prefix):
-                        dnametag.text = dname[len(prefix) :]
+
+            if strip_end and name.endswith(substr):
+                nametag.text = name[: len(name) - len(substr)]
+            elif name.startswith(substr):
+                nametag.text = name[len(substr) :]
+
+            dnametag = rtag.find("displayName")
+            if dnametag is not None:
+                dname = dnametag.text
+
+                if strip_end and dname.endswith(substr):
+                    dnametag.text = dname[: len(dname) - len(substr)]
+                elif dname.startswith(substr):
+                    dnametag.text = dname[len(substr) :]
 
     def collect_in_array(self, rspec, rmod):
         """Collect same registers in peripheral into register array."""


### PR DESCRIPTION
When using `_strip` in patches, it's not guaranteed that the `<displayName>` tag will be present. This resulted in an error for me when trying to patch a file.

While setting up and snooping around I also noticed that a couple of dev requirements were missing, and that the `home-page` URL in `pyproject.toml` was outdated.