### PR TITLE
Add support for multiple address blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ _modify:
         FSMC:
             description: Flexible static memory controller
 
+            # Multiple address blocks are supported via the addressBlocks list
+            # use either addressBlock or addressBlocks, but not both
+            addressBlocks:
+                -   offset: 0x0
+                    size: 0x400
+                    usage: "ADC base registers"
+                -   offset: 0x1000
+                    size: 0x400
+                    usage: "ADC extra registers"
+
+
+
 # Add whole new peripherals to this device.
 # Incredibly this feature is required.
 _add:
@@ -82,6 +94,15 @@ _add:
         addressBlock:
             offset: 0x0
             size: 0x400
+            usage: "All ADC registers"
+        # Multiple address blocks are supported via the addressBlocks list
+        addressBlocks:
+            -   offset: 0x0
+                size: 0x400
+                usage: "ADC base registers"
+            -   offset: 0x1000
+                size: 0x400
+                usage: "ADC extra registers"
         registers:
             CSR:
                 description: ADC Common status register

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -231,7 +231,19 @@ class Device:
         """Modify pspec inside device according to pmod."""
         for ptag in self.iter_peripherals(pspec):
             for (key, value) in pmod.items():
-                ptag.find(key).text = str(value)
+                if key == "addressBlock":
+                    ab = ptag.find(key)
+                    for (ab_key, ab_value) in value.items():
+                        ET.SubElement(ab, ab_key).text = str(ab_value)
+                elif key == "addressBlocks":
+                    for ab in ptag.findall("addressBlock"):
+                        ptag.remove(ab)
+                    for ab in value:
+                        ab_el = ET.SubElement(ptag, "addressBlock")
+                        for (ab_key, ab_value) in ab.items():
+                            ET.SubElement(ab_el, ab_key).text = str(ab_value)
+                else:
+                    ptag.find(key).text = str(value)
 
     def add_peripheral(self, pname, padd):
         """Add pname given by padd to device."""
@@ -257,6 +269,11 @@ class Device:
                 ab = ET.SubElement(pnew, "addressBlock")
                 for (ab_key, ab_value) in value.items():
                     ET.SubElement(ab, ab_key).text = str(ab_value)
+            elif key == "addressBlocks":
+                for ab in value:
+                    ab_el = ET.SubElement(ptag, "addressBlock")
+                    for (ab_key, ab_value) in ab.items():
+                        ET.SubElement(ab_el, ab_key).text = str(ab_value)
             elif key != "derivedFrom":
                 ET.SubElement(pnew, key).text = str(value)
         pnew.tail = "\n    "


### PR DESCRIPTION
SVD files allow multiple address blocks per peripheral.
This commit adds support for _add and _modify of peripherals with multiple addressblocks.
A new keyword (addressblocks) had to be introduced as YAML does not allow multiple config options with the same name. The addressblocks keyword supports a list of addressblocks.