### PR TITLE
Add makedeps script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/*.pyc
 **/*.pyo
 **/*.svd.patched
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,24 @@ before_install:
 
 install:
   - pip3 install virtualenv
-  - make venv
+  - make update-venv
   - make setup
-  - make install-svd2rust-form-rustfmt
+  - source venv/bin/activate
 
 before_script:
   - make check
 
-env:
-  - SCRIPT="check_stm32.sh"
-  - SCRIPT="check_esp32.sh"
-  - SCRIPT="check_lpc55.sh"
-
-matrix:
+jobs:
+  include:
+    - name: pytest
+      script: pytest svdtools
+    - name: check_stm32
+      script: bash tools/check_stm32.sh
+    - name: check_esp32
+      script: bash tools/check_esp32.sh
+    - name: check_lpc55
+      script: bash tools/check_lpc55.sh
   allow_failures:
-    - env: SCRIPT="check_esp32.sh"
+    - name: check_esp32
+      script: bash tools/check_esp32.sh
   fast_finish: true
-
-script:
-  - pytest svdtools
-  - bash tools/$SCRIPT

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ matrix:
   fast_finish: true
 
 script:
+  - pytest svdtools
   - bash tools/$SCRIPT

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 black
 flit
 isort
+pytest

--- a/svdtools/__init__.py
+++ b/svdtools/__init__.py
@@ -4,7 +4,7 @@ svdpatch.py
 
 import pathlib
 
-from . import patch
+from . import makedeps, patch
 
 __version__ = open(pathlib.Path(__file__).parent / "VERSION").read().strip()
 

--- a/svdtools/cli.py
+++ b/svdtools/cli.py
@@ -17,10 +17,19 @@ def patch(yaml_file):
 
 
 @click.command()
+@click.argument("yaml-file")
+@click.argument("deps-file")
+def makedeps(yaml_file, deps_file):
+    """Generate Make dependency file listing dependencies for a YAML file."""
+    svdtools.makedeps.main(yaml_file, deps_file)
+
+
+@click.command()
 def version():
     """Version of svdtools library and tool."""
     print(svdtools.__version__)
 
 
 svdtools_cli.add_command(patch)
+svdtools_cli.add_command(makedeps)
 svdtools_cli.add_command(version)

--- a/svdtools/makedeps.py
+++ b/svdtools/makedeps.py
@@ -1,0 +1,18 @@
+"""
+makedeps.py
+Copyright 2017, 2020 Adam Greig
+Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
+"""
+
+import yaml
+
+from . import patch
+
+
+def main(yaml_file, deps_file):
+    with open(yaml_file, encoding="utf-8") as f:
+        device = yaml.safe_load(f)
+    device["_path"] = yaml_file
+    deps = patch.yaml_includes(device)
+    with open(deps_file, "w") as f:
+        f.write("{}: {}\n".format(deps_file, " ".join(deps)))

--- a/svdtools/test/test_makedeps.py
+++ b/svdtools/test/test_makedeps.py
@@ -1,0 +1,30 @@
+import os.path
+
+import yaml
+
+from ..makedeps import main as makedeps
+
+
+def test_makedeps(tmpdir):
+    yaml_file = os.path.join(tmpdir, "test.yaml")
+    inc1_file = os.path.join(tmpdir, "inc1.yaml")
+    inc2_file = os.path.join(tmpdir, "inc2.yaml")
+    deps_file = os.path.join(tmpdir, "test.d")
+
+    device = {"_include": ["inc1.yaml"]}
+    inc1 = {"_include": ["inc2.yaml"]}
+    inc2 = {}
+
+    with open(yaml_file, "w") as f:
+        yaml.safe_dump(device, f)
+    with open(inc1_file, "w") as f:
+        yaml.safe_dump(inc1, f)
+    with open(inc2_file, "w") as f:
+        yaml.safe_dump(inc2, f)
+
+    makedeps(yaml_file, deps_file)
+
+    with open(deps_file) as f:
+        deps = f.read()
+
+    assert deps == f"{deps_file}: {inc1_file} {inc2_file}\n"

--- a/tools/check_esp32.sh
+++ b/tools/check_esp32.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source venv/bin/activate
+make install-svd2rust-form-rustfmt
 
 git clone https://github.com/esp-rs/esp32 --depth 1
 

--- a/tools/check_lpc55.sh
+++ b/tools/check_lpc55.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source venv/bin/activate
+make install-svd2rust-form-rustfmt
 
 git clone https://github.com/nickray/lpc55-pacs --depth 1
 

--- a/tools/check_stm32.sh
+++ b/tools/check_stm32.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source venv/bin/activate
+make install-svd2rust-form-rustfmt
 
 git clone https://github.com/stm32-rs/stm32-rs --depth 1
 


### PR DESCRIPTION
This is a straightforward port of [makedeps.py](https://github.com/stm32-rs/stm32-rs/blob/master/scripts/makedeps.py) but writing to the single output file instead of outputting many lines to stdout. By passing the output file path, it also knows what to put in the generated file without having to assume/be told you're using a ".deps" folder name.

For stm32-rs this allows updating the Makefile as:

```diff
diff --git a/Makefile b/Makefile
index 69be8d3..75b5ead 100644
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,6 @@ update-venv:
 # Generate dependencies for each device YAML
 .deps/%.d: devices/%.yaml
        @mkdir -p .deps
-       python3 scripts/makedeps.py $< > $@
+       svd makedeps $< $@

 -include .deps/*
```

This was a quick port so I did it first to sort of test the waters. Is there interest in bringing this and similar tools from stm32-rs into svdtools? I don't think every script needs or wants to be brought over, but there were a few I had in mind:

* makedeps (this PR): simple useful parsing of the YAML files to generate dependencies for Makefiles, very little extra code
* svdmmap: generates a text-based memory map of the entire device memory from a patched SVD, useful for diffing to see the impact of a YAML change
* makehtml: generates [stm32-rs's coverage webpages](https://stm32.agg.io/rs/STM32F107.html); I'd modify it to not be stm32-rs specific but I'd like to use this html output in another svd-patching-project and I think it applies pretty generally, but is a bunch more code and requires some static template files too
* possibly `matchperipherals`: checks which svd files a given peripheral file could cleanly apply to, useful if you've written descriptions for a peripheral for one device but suspect it would also be useful on many others
* possibly `interrupts`: lists interrupt table for SVD file, indicates gaps in interrupt number sequence that may represent missing interrupts
