### PR TITLE
Allow patterns in _strip/_strip_end

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ _rebase:
             # This would split MR into MRi where i = 0 ... bitlength
             _split: [MR]
 
-            # If fiels have unnecessary common prefix/postfix,
+            # If fields have unnecessary common prefix/postfix,
             # you can clean it in all registers in peripheral by:
             _strip:
                 - "PREFIX_*_"

--- a/README.md
+++ b/README.md
@@ -221,10 +221,12 @@ _rebase:
         _interrupts:
             - USART1
 
-    # If registers have unnecessary common prefix,
+    # If registers have unnecessary common prefix/postfix,
     # you can clean it in all registers in peripheral by:
     _strip:
-        - PREFIX_
+        - "PREFIX_*_"
+    _strip_end:
+        - "_POSTFIX_"
 
     # You can collect several same registers into one register array
     # that will be represented with svd2rust as array or elements
@@ -295,6 +297,15 @@ _rebase:
           IMR:
             # This would split MR into MRi where i = 0 ... bitlength
             _split: [MR]
+
+            # If fiels have unnecessary common prefix/postfix,
+            # you can clean it in all registers in peripheral by:
+            _strip:
+                - "PREFIX_*_"
+            _strip_end:
+                - "_POSTFIX_"
+
+
 ```
 
 ### Name Matching

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -6,12 +6,12 @@ Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
 """
 
 import copy
+import fnmatch
 import os.path
+import re
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
-import fnmatch
 from fnmatch import fnmatchcase
-import re
 
 import yaml
 
@@ -51,14 +51,15 @@ def matchname(name, spec):
         fnmatchcase(name, subspec) for subspec in spec.split(",")
     )
 
+
 def create_regex_from_pattern(substr, strip_end):
     """Create regex from pattern to match start or end of string."""
     regex = fnmatch.translate(substr)
     # make matching non-greedy
-    regex=re.sub('\\*', '*?', regex)
+    regex = re.sub("\\*", "*?", regex)
     # change to start of string search
     if not strip_end:
-        regex="^"+re.sub('\\\\Z$', '', regex)
+        regex = "^" + re.sub("\\\\Z$", "", regex)
     return re.compile(regex)
 
 
@@ -611,14 +612,14 @@ class Peripheral:
         Delete substring from register names inside ptag. Strips from the
         beginning of the name by default.
         """
-        regex = create_regex_from_pattern(substr, strip_end)        
+        regex = create_regex_from_pattern(substr, strip_end)
         for rtag in self.ptag.iter("register"):
             nametag = rtag.find("name")
-            nametag.text=regex.sub("",nametag.text)
+            nametag.text = regex.sub("", nametag.text)
 
             dnametag = rtag.find("displayName")
             if dnametag is not None:
-                dnametag.text=regex.sub("",dnametag.text)
+                dnametag.text = regex.sub("", dnametag.text)
 
     def collect_in_array(self, rspec, rmod):
         """Collect same registers in peripheral into register array."""
@@ -818,14 +819,14 @@ class Register:
         Delete substring from bitfield names inside rtag. Strips from the
         beginning of the name by default.
         """
-        regex = create_regex_from_pattern(substr, strip_end)        
+        regex = create_regex_from_pattern(substr, strip_end)
         for ftag in self.rtag.iter("field"):
             nametag = ftag.find("name")
-            nametag.text = regex.sub("",nametag.text)
+            nametag.text = regex.sub("", nametag.text)
 
             dnametag = ftag.find("displayName")
             if dnametag is not None:
-                dnametag.text = regex.sub("",dnametag.text)
+                dnametag.text = regex.sub("", dnametag.text)
 
     def modify_field(self, fspec, fmod):
         """Modify fspec inside rtag according to fmod."""

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -9,7 +9,9 @@ import copy
 import os.path
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
+import fnmatch
 from fnmatch import fnmatchcase
+import re
 
 import yaml
 
@@ -48,6 +50,16 @@ def matchname(name, spec):
     return (not spec.startswith("_")) and any(
         fnmatchcase(name, subspec) for subspec in spec.split(",")
     )
+
+def create_regex_from_pattern(substr, strip_end):
+    """Create regex from pattern to match start or end of string."""
+    regex = fnmatch.translate(substr)
+    # make matching non-greedy
+    regex=re.sub('\\*', '*?', regex)
+    # change to start of string search
+    if not strip_end:
+        regex="^"+re.sub('\\\\Z$', '', regex)
+    return re.compile(regex)
 
 
 def abspath(frompath, relpath):
@@ -599,25 +611,14 @@ class Peripheral:
         Delete substring from register names inside ptag. Strips from the
         beginning of the name by default.
         """
+        regex = create_regex_from_pattern(substr, strip_end)        
         for rtag in self.ptag.iter("register"):
             nametag = rtag.find("name")
-            name = nametag.text
-
-            if strip_end:
-                if name.endswith(substr):
-                    nametag.text = name[: -len(substr)]
-            elif name.startswith(substr):
-                nametag.text = name[len(substr) :]
+            nametag.text=regex.sub("",nametag.text)
 
             dnametag = rtag.find("displayName")
             if dnametag is not None:
-                dname = dnametag.text
-
-                if strip_end:
-                    if dname.endswith(substr):
-                        dnametag.text = dname[: -len(substr)]
-                elif dname.startswith(substr):
-                    dnametag.text = dname[len(substr) :]
+                dnametag.text=regex.sub("",dnametag.text)
 
     def collect_in_array(self, rspec, rmod):
         """Collect same registers in peripheral into register array."""
@@ -817,25 +818,14 @@ class Register:
         Delete substring from bitfield names inside rtag. Strips from the
         beginning of the name by default.
         """
+        regex = create_regex_from_pattern(substr, strip_end)        
         for ftag in self.rtag.iter("field"):
             nametag = ftag.find("name")
-            name = nametag.text
-
-            if strip_end:
-                if name.endswith(substr):
-                    nametag.text = name[: -len(substr)]
-            elif name.startswith(substr):
-                nametag.text = name[len(substr) :]
+            nametag.text = regex.sub("",nametag.text)
 
             dnametag = ftag.find("displayName")
             if dnametag is not None:
-                dname = dnametag.text
-
-                if strip_end:
-                    if dname.endswith(substr):
-                        dnametag.text = dname[: -len(substr)]
-                elif dname.startswith(substr):
-                    dnametag.text = dname[len(substr) :]
+                dnametag.text = regex.sub("",dnametag.text)
 
     def modify_field(self, fspec, fmod):
         """Modify fspec inside rtag according to fmod."""


### PR DESCRIPTION
Allows patterns in _strip/_stripend. This makes it easier to remove repetitive suffixes (like e.g. enable1 in register pin1)
The patterns use filename global syntax and match shortest prefix/postfix possible.