### PR TITLE
Changes from avr-device

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,15 @@ _rebase:
             FIELD:
               description: NEWDESC
 
+              # Change the writeConstraint of a field to enumerateValues
+              _write_constraint: "enum"
+
+              # Remove any writeConstraint from this field
+              _write_constraint: "none"
+
+              # Change the writeConstraint of a field to a range of values
+              _write_constraint: [MINIMUM, MAXIMUM]
+
         # Add new fields to this register
         _add:
             NEWFIELD:

--- a/README.md
+++ b/README.md
@@ -281,6 +281,13 @@ _rebase:
             VARIANT: [VALUE, DESCRIPTION]
             VARIANT: [VALUE, DESCRIPTION]
 
+        FIELD:
+            # If a field already has enumerateValues, drop them and
+            # replace them with entirely new ones.
+            _replace_enum:
+                VARIANT: [VALUE, DESCRIPTION]
+                VARIANT: [VALUE, DESCRIPTION]
+
         # Another field. A list of two numbers gives a range writeConstraint.
         FIELD: [MINIMUM, MAXIMUM]
 

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -832,14 +832,10 @@ class Register:
         """Modify fspec inside rtag according to fmod."""
         for ftag in self.iter_fields(fspec):
             for (key, value) in fmod.items():
-                try:
-                    ftag.find(key).text = str(value)
-                except AttributeError:
-                    raise SvdPatchError(
-                        "invalid attribute {!r} for register {}, field {}".format(
-                            key, self.rtag.find("name").text, ftag.find("name").text
-                        )
-                    )
+                tag = ftag.find(key)
+                if tag is None:
+                    tag = ET.SubElement(ftag, key)
+                tag.text = str(value)
 
     def add_field(self, fname, fadd):
         """Add fname given by fadd to rtag."""

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -526,9 +526,11 @@ class Peripheral:
         for rtag in self.iter_registers(rspec):
             for (key, value) in rmod.items():
                 tag = rtag.find(key)
-                if value == "":
+                if value == "" and tag is not None:
                     rtag.remove(tag)
-                else:
+                elif value != "":
+                    if tag is None:
+                        tag = ET.SubElement(rtag, key)
                     tag.text = str(value)
 
     def add_register(self, rname, radd):

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -923,22 +923,26 @@ class Register:
 
     def process_field_enum(self, pname, fspec, field, usage="read-write"):
         """Add an enumeratedValues given by field to all fspec in rtag."""
-        derived = None
+        derived, enum, enum_name, enum_usage = None, None, None, None
         for ftag in self.iter_fields(fspec):
             name = ftag.find("name").text
-            if derived is None:
+
+            if enum is None:
                 enum = make_enumerated_values(name, field, usage=usage)
                 enum_name = enum.find("name").text
                 enum_usage = enum.find("usage").text
-                for ev in ftag.iter("enumeratedValues"):
-                    ev_usage = ev.find("usage").text
-                    if ev_usage == enum_usage or ev_usage == "read-write":
-                        print(pname, fspec, field)
-                        raise SvdPatchError(
-                            "{}: field {} already has enumeratedValues for {}".format(
-                                pname, name, ev_usage
-                            )
+
+            for ev in ftag.iter("enumeratedValues"):
+                ev_usage = ev.find("usage").text
+                if ev_usage == enum_usage or ev_usage == "read-write":
+                    print(pname, fspec, field)
+                    raise SvdPatchError(
+                        "{}: field {} already has enumeratedValues for {}".format(
+                            pname, name, ev_usage
                         )
+                    )
+
+            if derived is None:
                 ftag.append(enum)
                 derived = make_derived_enumerated_values(enum_name)
             else:


### PR DESCRIPTION
Hello!

Over at [`avr-device`][avr-device] we've been happy users of svdpatch for quite some time (If you're wondering, we created a [tool][atdf2svd] to convert the AVR register descriptions to SVD).  We've accumulated a few changes to the patching script, which I have now forward-ported so they could be applied here, to hopefully be useful for other people as well.  In particular:

#### 88fdde906f48 ("Allow overwriting enumeratedValues with _replace_enum")
> Add a new patch directive which allows overwriting existing enumerated values.  Example:
>
> ```yaml
> ADC:
>   _modify:
>     ADCSRA:
>       access: read-write
>   ADCSRA:
>     ADPS:
>       _replace_enum:
>         PRESCALER_2: [1, "Prescaler Value 2"]
>         PRESCALER_4: [2, "Prescaler Value 4"]
>         PRESCALER_8: [3, "Prescaler Value 8"]
>         PRESCALER_16: [4, "Prescaler Value 16"]
>         PRESCALER_32: [5, "Prescaler Value 32"]
>         PRESCALER_64: [6, "Prescaler Value 64"]
>         PRESCALER_128: [7, "Prescaler Value 128"]
> ```
>
> In this case, any enumerated values for ADCSRA[ADPS] would be removed in favor of the new ones.

Our SVD files commonly contain enumerated values already, but with stupid names (e.g. `VAL_0x01`, `VAL_0x02`, `VAL_0x03`, ...).  So we added a feature which allows replacing them with entirely new ones.

#### c6f1552dc38c ("Allow field _modify to create new tags")
> When a field does not yet have a certain tag, allow _modify to add it instead of returning an error.  For example, if `<description>` is missing, this change allows _modify to add it:
>
> ```yaml
> TWI:
>   TWAMR:
>     _modify:
>       TWAM:
>         description: "TWI Address Mask Bits"
> ```

#### 09e8f7a1e04b ("Add _write_constraint field modifier")
> `_write_constraint` allows to change the write-constraint of a field to one of:
>
> - "enum": Allow only enumerated values (useEnumeratedValues).
> - "none": Completely remove the `<writeConstraint>` tag.
> - `[min, max]`: Allow only values in a certain range.
>
> This is useful, for example, when patching a field with a range constraint to use enumerated values instead:
>
> ```yaml
> PLL:
>   PLLFRQ:
>     _modify:
>       PLLTM:
>         description: "PLL Postscaler for High Speed Timer"
>         _write_constraint: enum
>     PLLTM:
>       DISCONNECTED: [0, "0 (Disconnected)"]
>       FACTOR_1:     [1, "1"]
>       FACTOR_15:    [2, "1.5"]
>       FACTOR_2:     [3, "2"]
> ```

[avr-device]: https://github.com/Rahix/avr-device
[atdf2svd]: https://github.com/Rahix/atdf2svd