### PR TITLE
Add a check for the esp8266

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ jobs:
   include:
     - name: pytest
       script: pytest svdtools
-    - name: check_stm32
-      script: bash tools/check_stm32.sh
     - name: check_esp32
       script: bash tools/check_esp32.sh
+    - name: check_esp8266
+      script: bash tools/check_esp8266.sh
+    - name: check_stm32
+      script: bash tools/check_stm32.sh
     - name: check_lpc55
       script: bash tools/check_lpc55.sh
   allow_failures:

--- a/tools/check_esp8266.sh
+++ b/tools/check_esp8266.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+make install-svd2rust-form-rustfmt
+
+git clone https://github.com/esp-rs/esp8266 --depth 1
+
+make -C esp8266/ patch
+
+rm -rf esp8266


### PR DESCRIPTION
The [esp-rs/esp8266](https://github.com/esp-rs/esp8266) repo is using `svdtools` as well, so I figured we may as well check against that too. ~~I also noticed that the *check_esp32* entry in `.travis.yml` was in both `include` and `allow_failures`, so I de-duplicated it.~~ (Turns out we need that for some reason :) )