### PR TITLE
Update patch to generate schema-compliant SVD output

### DIFF
--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -341,10 +341,6 @@ class UnknownTagError(SvdPatchError):
     pass
 
 
-class DuplicateTagError(SvdPatchError):
-    pass
-
-
 class Device:
     """Class collecting methods for processing device contents"""
 
@@ -1183,9 +1179,6 @@ class Register:
         """Add a writeConstraint range given by field to all fspec in rtag."""
         set_any = False
         for ftag in self.iter_fields(fspec):
-            if ftag.find("writeConstraint") is not None:
-                raise DuplicateTagError("Duplicate writeConstraint for {}"
-                                        .format(ftag.find("name").text))
             ftag.append(make_write_constraint(field))
             set_any = True
         if not set_any:

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -341,6 +341,10 @@ class UnknownTagError(SvdPatchError):
     pass
 
 
+class DuplicateTagError(SvdPatchError):
+    pass
+
+
 class Device:
     """Class collecting methods for processing device contents"""
 
@@ -388,8 +392,6 @@ class Device:
                     for ab in value:
                         ab_el = ET.SubElement(ptag, "addressBlock")
                         for (ab_key, ab_value) in ab.items():
-                            if ab.find(ab_key):
-                                ab.remove(ab.find(ab_key))
                             ET.SubElement(ab_el, ab_key).text = str(ab_value)
                 else:
                     tag = ptag.find(key)
@@ -1181,6 +1183,9 @@ class Register:
         """Add a writeConstraint range given by field to all fspec in rtag."""
         set_any = False
         for ftag in self.iter_fields(fspec):
+            if ftag.find("writeConstraint") is not None:
+                raise DuplicateTagError("Duplicate writeConstraint for {}"
+                                        .format(ftag.find("name").text))
             ftag.append(make_write_constraint(field))
             set_any = True
         if not set_any:


### PR DESCRIPTION
Currently most SVD files generated by `patch` are not SVD schema compliant, usually because the ordering of child elements is incorrect. For example, in SVD it's required that `dim`, `dimIncrement`, and `dimIndex`, if present in an element, are always first and in that order, which was always violated by `patch` before this PR.

This PR sorts SVDs into the correct order before outputting. It's still possible for a generated SVD to be invalid, for example if a patch generates multiple `writeConstraint` entries. Fixing that is left for a later PR as it's more likely to cause breaking changes in CI.