### PR TITLE
Fix and document copy_peripheral behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ _add:
 # A new peripheral can have all its registers copied from another, in case
 # it cannot quite be derivedFrom (e.g. some fields need different enumerated
 # values) but it's otherwise almost exactly the same.
-# The registers are copied but not name or address or interrupts.
+# The registers are copied but not name or address or interrupts, which are
+# preserved if the target already exists.
 _copy:
     ADC3:
         from: ADC2
@@ -142,6 +143,7 @@ _copy:
 # The new peripheral can also be copied from another svd file for a different
 # device. This is useful when a peripheral is missing in a device but the exact
 # same peripheral already exist in another device.
+# When copying from another file, all fields including interrupts are copied.
 _copy:
     TIM1:
         from: ../svd/stm32f302.svd:TIM1


### PR DESCRIPTION
Previously `copy_peripheral` did not quite do what it promised; some interrupts from the template would be copied incorrectly and some interrupts already on the target would not be preserved though they should have been, but in a very chaotic way that was hard to predict. The recent change in https://github.com/stm32-rs/svdtools/pull/35 muddied the water further.

This PR fixes those bugs and better documents the expected behaviour. It fixes the regression in https://github.com/stm32-rs/stm32-rs/pull/440 and in fact makes the situation a little better, as many interrupts are now associated with the correct peripheral. This should be at least no worse than the 0.1.7 behaviour and fixes the change in 0.1.8, so I intend to release this ASAP.