### PR TITLE
Update lpc55-pac repository

### DIFF
--- a/tools/check_lpc55.sh
+++ b/tools/check_lpc55.sh
@@ -7,6 +7,6 @@ make install-svd2rust-form-rustfmt
 git clone https://github.com/lpc55/lpc55-pac --depth 1
 
 make -C lpc55-pac/ patch generate
-make -C lpc55-pac/ generate
+(cd lpc55-pac && cargo check)
 
 rm -rf lpc55-pacs

--- a/tools/check_lpc55.sh
+++ b/tools/check_lpc55.sh
@@ -4,9 +4,9 @@ set -e
 
 make install-svd2rust-form-rustfmt
 
-git clone https://github.com/nickray/lpc55-pacs --depth 1
+git clone https://github.com/lpc55/lpc55-pac --depth 1
 
-make -C lpc55-pacs/ patch generate
-make -C lpc55-pacs/ generate
+make -C lpc55-pac/ patch generate
+make -C lpc55-pac/ generate
 
 rm -rf lpc55-pacs


### PR DESCRIPTION
Moved the repo into the `lpc55` organization, keeping up :)

Do you think it would make sense to build the PAC as well? For stm32 it's probably too much, but for lpc55 (on my relatively beefy machine...) a simple `cargo build` takes ~30 seconds, which seems acceptable?