### PR TITLE
Fix LPC55 check

### DIFF
--- a/tools/check_lpc55.sh
+++ b/tools/check_lpc55.sh
@@ -6,7 +6,6 @@ make install-svd2rust-form-rustfmt
 
 git clone https://github.com/lpc55/lpc55-pac --depth 1
 
-make -C lpc55-pac/ patch generate
-(cd lpc55-pac && cargo check)
+make -C lpc55-pac/ check
 
-rm -rf lpc55-pacs
+rm -rf lpc55-pac


### PR DESCRIPTION
Apologies for the noise :)

We recently jumped ahead of the overdue svd2rust release, patching out some old lints but mainly [getting rid of bare-metal](https://github.com/lpc55/lpc55-pac/commit/7a033fbfb118f1177b8c7080a582dbab6604a5aa) (using interrupt::Nr from cortex-m instead), which led to a failure here. Added a dedicated [check target](https://github.com/lpc55/lpc55-pac/commit/1125223de278fb5db82ce640ab0e2bd6bb3d1ad9) now.

Answers https://github.com/stm32-rs/svdtools/pull/48#issuecomment-787467450.