### PR TITLE
Swap to using lxml instead of stdlib xml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Check
         run: |
           black --check svdtools
-          isort --check-only --recursive svdtools
+          isort --check-only svdtools
       - name: Test
         run: pytest svdtools
   check:

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ apply-black:
 	venv/bin/black svdtools/
 
 apply-isort:
-	venv/bin/isort -y --recursive svdtools/
+	venv/bin/isort svdtools/
 
 check-isort:
-	venv/bin/isort --check-only --recursive svdtools/
+	venv/bin/isort --check-only svdtools/
 
 semi-clean:
 	rm -rf **/__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ description-file = "README.md"
 requires = [
   "click ~= 7.0",
   "PyYAML ~= 5.3",
+  "lxml ~= 4.6",
 ]
 classifiers=[
     "License :: OSI Approved :: MIT License",

--- a/svdtools/interrupts.py
+++ b/svdtools/interrupts.py
@@ -4,7 +4,7 @@ Copyright 2018-2020 Adam Greig
 Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
 """
 
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 
 def parse_device(svd_file):

--- a/svdtools/mmap.py
+++ b/svdtools/mmap.py
@@ -6,6 +6,7 @@ Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
 """
 
 import copy
+
 import lxml.etree as ET
 
 

--- a/svdtools/mmap.py
+++ b/svdtools/mmap.py
@@ -6,7 +6,7 @@ Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
 """
 
 import copy
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 
 def get_field_offset_width(ftag):

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -9,10 +9,10 @@ import copy
 import fnmatch
 import os.path
 import re
-import lxml.etree as ET
 from collections import OrderedDict
 from fnmatch import fnmatchcase
 
+import lxml.etree as ET
 import yaml
 
 DEVICE_CHILDREN = [

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -9,7 +9,7 @@ import copy
 import fnmatch
 import os.path
 import re
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 from collections import OrderedDict
 from fnmatch import fnmatchcase
 

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -1223,9 +1223,9 @@ class Register:
 
             if derived is None:
                 ftag.append(enum)
-                derived = make_derived_enumerated_values(enum_name)
+                derived = enum_name
             else:
-                ftag.append(derived)
+                ftag.append(make_derived_enumerated_values(derived))
         if derived is None:
             rname = self.rtag.find("name").text
             raise MissingFieldError(

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -337,9 +337,15 @@ def sort_element(tag):
     }
     if len(tag) > 0 and tag.tag not in orders:
         raise UnknownTagError(tag.tag)
+    comments = []
     for child in tag:
-        if child.tag not in orders[tag.tag]:
+        if child.tag is ET.Comment:
+            comments.append(child)
+        elif child.tag not in orders[tag.tag]:
             raise UnknownTagError((tag.tag, child.tag))
+    for comment in comments:
+        # Remove interior comments, which we cannot sort.
+        tag.remove(comment)
     tag[:] = sorted(tag, key=lambda e: orders[tag.tag].index(e.tag))
 
 
@@ -1023,7 +1029,7 @@ class Register:
         Iterates over all fields that match fspec and live inside rtag.
         """
         fields = self.rtag.find("fields")
-        if fields:
+        if fields is not None:
             for ftag in fields.iter("field"):
                 name = ftag.find("name").text
                 if matchname(name, fspec):


### PR DESCRIPTION
lxml's ElementTree API preserves comments in the original XML, which allows us to preserve licensing comments often found in SVD files.

Adding a new dependency is a bit of a shame, but lxml is already widely used and available.