### PR TITLE
Custom name and description for _split

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ _rebase:
           IMR:
             # This would split MR into MRi where i = 0 ... bitlength
             _split: [MR]
+            # This would split CHxFM into CHiFM where i = 0 ... bitlength
+            # and use the current bit for the description in each field
+            _split:
+              CHxFM:
+                name: CH%sFM
+                description: Processor 2 transmit channel %s free interrupt mask
 
             # If fields have unnecessary common prefix/postfix,
             # you can clean it in all registers in peripheral by:

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -1018,7 +1018,11 @@ class Peripheral:
                 r.merge_fields(fspec)
             # Handle splits
             for fspec in register.get("_split", []):
-                fsplit = register["_split"][fspec] if isinstance(register["_split"], dict) else {}
+                fsplit = (
+                    register["_split"][fspec]
+                    if isinstance(register["_split"], dict)
+                    else {}
+                )
                 r.split_fields(fspec, fsplit)
             # Handle strips
             for prefix in register.get("_strip", []):
@@ -1215,7 +1219,10 @@ class Register:
         ET.SubElement(ftag, "dimIncrement").text = hex(dimIncrement)
 
     def split_fields(self, fspec, fsplit):
-        """split all fspec in rtag."""
+        """
+        Split all fspec in rtag.
+        Name and description can be customized with %s as a placeholder to the iterator value.
+        """
         fields = list(self.iter_fields(fspec))
         if len(fields) == 0:
             rname = self.rtag.find("name").text
@@ -1223,12 +1230,12 @@ class Register:
                 "Could not find any fields to split {}.{}".format(rname, fspec)
             )
         parent = self.rtag.find("fields")
-        if fsplit and 'name' in fsplit:
-            name = fsplit['name']
+        if isinstance(fsplit, dict) and "name" in fsplit:
+            name = fsplit["name"]
         else:
-            name = os.path.commonprefix([f.find("name").text for f in fields]) + '%s'
-        if fsplit and 'description' in fsplit:
-            desc = fsplit['description']
+            name = os.path.commonprefix([f.find("name").text for f in fields]) + "%s"
+        if isinstance(fsplit, dict) and "description" in fsplit:
+            desc = fsplit["description"]
         else:
             desc = fields[0].find("description").text
         bitoffset = get_field_offset_width(fields[0])[0]
@@ -1236,8 +1243,8 @@ class Register:
         parent.remove(fields[0])
         for i in range(bitwidth):
             fnew = ET.SubElement(parent, "field")
-            ET.SubElement(fnew, "name").text = name.replace('%s', str(i))
-            ET.SubElement(fnew, "description").text = desc.replace('%s', str(i))
+            ET.SubElement(fnew, "name").text = name.replace("%s", str(i))
+            ET.SubElement(fnew, "description").text = desc.replace("%s", str(i))
             ET.SubElement(fnew, "bitOffset").text = str(bitoffset + i)
             ET.SubElement(fnew, "bitWidth").text = str(1)
 


### PR DESCRIPTION
This pull request allow to specify a custom name and description for `_split` with support for a placeholder to put the iterator value in the string.

Example:
```yaml
  C1MR:
    _split:
      CHxFM: 
        name: CH%sFM
        description: Processor 1 transmit channel %s status set
      CHxOM: 
        name: CH%sOM
        description: Processor 1 receive channel %s status clear
```