### PR TITLE
Support array of fspec and renaming for _merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,18 @@ _rebase:
         _merge:
             - "FIELD*"
 
+        # You can also merge fields with different base name like this:
+        _merge:
+            FIELD: [FIELD1, FIELD_?]
+        # Or like this:
+        _merge:
+            FIELD:
+                - FIELD1
+                - FIELD_?
+        # Or even like this:
+        _merge:
+            NEW_FIELD: "FIELD*"
+
         # A field in this register, matches an SVD <field> tag
         FIELD:
             # By giving the field a dictionary we construct an enumerateValues


### PR DESCRIPTION
This pull request allow to specify a different name when merging fields, and allow to use a list of fspec to merge instead of just getting the common base name.

Example:

```yaml
        # You can also merge fields with different base name like this:
        _merge:
            FIELD: [FIELD1, FIELD_?]
        # Or like this:
        _merge:
            FIELD:
                - FIELD1
                - FIELD_?
        # Or even like this:
        _merge:
            NEW_FIELD: "FIELD*"
```