### PR TITLE
Add detection of duplicate keys. Closes #63.

### DIFF
--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -36,8 +36,14 @@ DEVICE_CHILDREN = [
 
 
 # Set up pyyaml to use ordered dicts so we generate the same
-# XML output each time
-def dict_constructor(loader, node):
+# XML output each time, and detect and refuse duplicate keys.
+def dict_constructor(loader, node, deep=False):
+    mapping = set()
+    for key_node, _ in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        start = node.start_mark
+        assert key not in mapping, f"duplicate key '{key}' found {start}"
+        mapping.add(key)
     return OrderedDict(loader.construct_pairs(node))
 
 


### PR DESCRIPTION
This turned out to be easier than I thought, especially since we already override this method for OrderedDicts. Unsurprisingly it's found a whole load of duplicate keys in stm32-rs though which I guess will need fixing before we can pass CI, heh.