### PR TITLE
Fix computing offset of fields that specify a bitRange instead

### DIFF
--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -1057,7 +1057,7 @@ class Peripheral:
 
 
 def sorted_fields(fields):
-    return sorted(fields, key=lambda ftag: int(ftag.find("bitOffset").text, 0))
+    return sorted(fields, key=lambda ftag: get_field_offset_width(ftag)[0])
 
 
 class Register:
@@ -1217,7 +1217,7 @@ class Register:
         for ftag in list(self.iter_fields(fspec)):
             fname = ftag.findtext("name")
             fields.append(
-                [ftag, fname[li : len(fname) - ri], int(ftag.findtext("bitOffset"), 0)]
+                [ftag, fname[li : len(fname) - ri], get_field_offset_width(ftag)[0]]
             )
         dim = len(fields)
         if dim == 0:


### PR DESCRIPTION
In #74 the behaviour for sorting fields when working out enumerated values changed to use the `bitOffset` attribute instead of sorting for natural numbers inside the name. This worked fine in our tests, but the RP2040 SVD uses `bitRange` for many of its fields, which therefore didn't have a `bitOffset`. We already have a `get_field_offset_width` method that does the right thing, so this PR swaps to using it. The RP2040 SVD now patches OK, and the stm32-rs SVDs are all identical after this change too.