### PR TITLE
Remove displayName from derived registers when it exists. Fixes #83

### DIFF
--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -807,7 +807,7 @@ class Peripheral:
                 )
             if rtag.find("name").text == srcname:
                 source = rtag
-        if source == None:
+        if source is None:
             raise SvdPatchError(
                 "peripheral {} does not have register {}".format(
                     self.ptag.find("name").text, srcname
@@ -815,7 +815,8 @@ class Peripheral:
             )
         rcopy = copy.deepcopy(source)
         rcopy.find("name").text = rname
-        rcopy.find("displayName").text = rname
+        if rcopy.find("displayName") is not None:
+            rcopy.remove(rcopy.find("displayName"))
         for (key, value) in rderive.items():
             if key == "_from":
                 continue


### PR DESCRIPTION
This should fix the issue in #83. There's not really any point us setting `displayName` to the same as `name`, so just remove it instead, but only do that if it's actually there.

@mgottschlag, would you mind checking this does what you expect on rp2040-pac? I've run it on your branch and it does patch without any errors and the diff looks ok, but I'd appreciate if you could confirm it is doing what you wanted.

cc https://github.com/rp-rs/rp2040-pac/pull/41