### PR TITLE
move _strips before _modify

### DIFF
--- a/CHANGELOG-python.md
+++ b/CHANGELOG-python.md
@@ -5,6 +5,8 @@ This changelog tracks the Python `svdtools` project. See
 
 ## [Unreleased]
 
+* Move `_strip`, `_strip_end` before `_modify`
+
 ## [v0.1.23] 2022-05-01
 
 * Add support for `modifiedWriteValues` & `readAction` for fields

--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -5,6 +5,8 @@ This changelog tracks the Rust `svdtools` project. See
 
 ## [Unreleased]
 
+* Move `_strip`, `_strip_end` before `_modify`
+
 ## [v0.2.5] 2022-07-23
 
 * update `svd-rs` crates to 0.14

--- a/src/patch/peripheral.rs
+++ b/src/patch/peripheral.rs
@@ -170,6 +170,16 @@ impl PeripheralExt for Peripheral {
                 .with_context(|| format!("Copying register `{}`", rname))?
         }
 
+        // Handle strips
+        for prefix in pmod.str_vec_iter("_strip") {
+            self.strip_start(prefix)
+                .with_context(|| format!("Stripping prefix `{}` from register names", prefix))?;
+        }
+        for suffix in pmod.str_vec_iter("_strip_end") {
+            self.strip_end(suffix)
+                .with_context(|| format!("Stripping suffix `{}` from register names", suffix))?;
+        }
+
         // Handle modifications
         for (rspec, rmod) in pmod.hash_iter("_modify") {
             let rmod = rmod.hash()?;
@@ -202,16 +212,6 @@ impl PeripheralExt for Peripheral {
                     .modify_register(rspec, rmod)
                     .with_context(|| format!("Modifying registers matched to `{}`", rspec))?,
             }
-        }
-
-        // Handle strips
-        for prefix in pmod.str_vec_iter("_strip") {
-            self.strip_start(prefix)
-                .with_context(|| format!("Stripping prefix `{}` from register names", prefix))?;
-        }
-        for suffix in pmod.str_vec_iter("_strip_end") {
-            self.strip_end(suffix)
-                .with_context(|| format!("Stripping suffix `{}` from register names", suffix))?;
         }
 
         // Handle field clearing

--- a/src/patch/register.rs
+++ b/src/patch/register.rs
@@ -99,6 +99,16 @@ impl RegisterExt for Register {
                 .with_context(|| format!("Deleting fields matched to `{}`", fspec))?;
         }
 
+        // Handle strips
+        for prefix in rmod.str_vec_iter("_strip") {
+            self.strip_start(prefix)
+                .with_context(|| format!("Stripping prefix `{}` from field names", prefix))?;
+        }
+        for suffix in rmod.str_vec_iter("_strip_end") {
+            self.strip_end(suffix)
+                .with_context(|| format!("Stripping suffix `{}` from field names", suffix))?;
+        }
+
         // Handle field clearing
         for fspec in rmod.str_vec_iter("_clear") {
             self.clear_field(fspec)
@@ -154,16 +164,6 @@ impl RegisterExt for Register {
                 }
             }
             _ => {}
-        }
-
-        // Handle strips
-        for prefix in rmod.str_vec_iter("_strip") {
-            self.strip_start(prefix)
-                .with_context(|| format!("Stripping prefix `{}` from field names", prefix))?;
-        }
-        for suffix in rmod.str_vec_iter("_strip_end") {
-            self.strip_end(suffix)
-                .with_context(|| format!("Stripping suffix `{}` from field names", suffix))?;
         }
 
         // Handle fields

--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -671,6 +671,11 @@ class Device:
             for rname in peripheral.get("_copy", {}):
                 rderive = peripheral["_copy"][rname]
                 p.copy_register(rname, rderive)
+            # Handle strips
+            for prefix in peripheral.get("_strip", []):
+                p.strip(prefix)
+            for suffix in peripheral.get("_strip_end", []):
+                p.strip(suffix, strip_end=True)
             # Handle modifications
             for rspec in peripheral.get("_modify", {}):
                 rmod = peripheral["_modify"][rspec]
@@ -685,11 +690,6 @@ class Device:
                         p.modify_cluster(cspec, rmod[cspec])
                 else:
                     p.modify_register(rspec, rmod)
-            # Handle strips
-            for prefix in peripheral.get("_strip", []):
-                p.strip(prefix)
-            for suffix in peripheral.get("_strip_end", []):
-                p.strip(suffix, strip_end=True)
             # Handle field clearing
             for rspec in peripheral.get("_clear_fields", []):
                 p.clear_fields(rspec)
@@ -1120,6 +1120,11 @@ class Peripheral:
             # Handle deletions
             for fspec in register.get("_delete", []):
                 r.delete_field(fspec)
+            # Handle strips
+            for prefix in register.get("_strip", []):
+                r.strip(prefix)
+            for suffix in register.get("_strip_end", []):
+                r.strip(suffix, strip_end=True)
             # Handle field clearing
             for fspec in register.get("_clear", []):
                 r.clear_field(fspec)
@@ -1147,11 +1152,6 @@ class Peripheral:
                     else {}
                 )
                 r.split_fields(fspec, fsplit)
-            # Handle strips
-            for prefix in register.get("_strip", []):
-                r.strip(prefix)
-            for suffix in register.get("_strip_end", []):
-                r.strip(suffix, strip_end=True)
             # Handle fields
             if update_fields:
                 for fspec in register:


### PR DESCRIPTION
This is breaking change.
But this let reuse patches for registers with and without prefixes.