### PR TITLE
Add support for PyYAML v6

### DIFF
--- a/CHANGELOG-python.md
+++ b/CHANGELOG-python.md
@@ -5,6 +5,8 @@ This changelog tracks the Python `svdtools` project. See
 
 ## [Unreleased]
 
+* Add support for PyYAML v6
+
 ## [v0.1.21] 2022-01-15
 
 * Provide option to opt out of regex replace of 0's in description when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.6"
 description-file = "README.md"
 requires = [
   "click ~= 8.0",
-  "PyYAML ~= 5.3",
+  "PyYAML >= 5.3, < 7",
   "lxml ~= 4.6",
   "braceexpand ~= 0.1.7",
 ]


### PR DESCRIPTION
Changelog: <https://github.com/yaml/pyyaml/releases/tag/6.0>

PyYAML released version 6, and the only breaking change is "always require `Loader` arg to `yaml.load()`", which would have resulted in a deprecation warning with version 5.

Supporting both 5 and 6 makes this easier for people to use during the transition phase because PyYAML is often provided as an OS package on Linux distributions.