### PR TITLE
feat: `convert`: Add `format_config` option

### DIFF
--- a/CHANGELOG-rust.md
+++ b/CHANGELOG-rust.md
@@ -5,6 +5,8 @@ This changelog tracks the Rust `svdtools` project. See
 
 ## [Unreleased]
 
+* `convert`: Add `format_config` option
+
 ## [v0.2.4] 2022-05-15
 
 * Added action to build binaries and release for every version tag and latest commit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ edition = "2021"
 clap = { version = "3.0", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.18", features = ["serialize"] }
-svd-rs = { version = "0.13.2", features = ["serde", "derive-from"]  }
-svd-parser = { version = "0.13.4", features = ["expand"] }
-svd-encoder = "0.13.1"
+svd-rs = { version = "0.14.0", features = ["serde", "derive-from"] }
+svd-parser = { version = "0.14.0", features = ["expand"] }
+svd-encoder = "0.14.0"
 yaml-rust = "0.4"
 serde_yaml = "0.8.23"
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,14 @@ enum Command {
         /// Skip enumeratedValues and writeConstraints during parsing (XML input only)
         #[clap(long)]
         ignore_enums: bool,
+
+        /// Path to format config file
+        ///
+        /// If not specified, the default format config will be used.
+        ///
+        /// Only used for SVD output format.
+        #[clap(long = "format-config", parse(from_os_str))]
+        format_config: Option<PathBuf>,
     },
 }
 
@@ -94,6 +102,7 @@ impl Command {
                 expand,
                 expand_properties,
                 ignore_enums,
+                format_config,
             } => convert_cli::convert(
                 in_path,
                 out_path,
@@ -102,6 +111,7 @@ impl Command {
                 *expand,
                 *expand_properties,
                 *ignore_enums,
+                format_config.as_ref().map(|p| p.as_path()),
             )?,
         }
         Ok(())


### PR DESCRIPTION
## Intro

We can use `svdtools convert <input.svd> <output.svd> --format-config <format_config.yaml/json>` to format an SVD file now.

For example, we have `.svdfmt.yaml` with the below lines:

```YAML
peripheral_name: Constant
peripheral_base_address: UpperHex16
```

The output SVD file will have peripheral names in `CONSTANT_CASE` and addresses like `0x00ABCDEF` or `0x0123456789ABCDEF`.

The available config is in [`svd-encoder`](https://github.com/rust-embedded/svd/blob/master/svd-encoder/src/config.rs)

Only support SVD output via `svd-encoder` for now.