### PR TITLE
Accept a YAML file, not an SVD file, when patching

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,9 +12,9 @@ use svdtools::{
 enum Command {
     /// Patches an SVD file as specified by a YAML file
     Patch {
-        /// Path to input SVD file
+        /// Path to input YAML file
         #[clap(parse(from_os_str))]
-        svd_file: PathBuf,
+        yaml_file: PathBuf,
     },
     /// Generate Make dependency file listing dependencies for a YAML file.
     Makedeps {
@@ -89,7 +89,7 @@ impl Command {
                 interrupts_cli::parse_device(svd_file, !no_gaps)?;
             }
             Self::Mmap { svd_file } => mmap_cli::parse_device(svd_file)?,
-            Self::Patch { svd_file } => patch_cli::patch(svd_file)?,
+            Self::Patch { yaml_file } => patch_cli::patch(yaml_file)?,
             Self::Makedeps {
                 yaml_file,
                 deps_file,


### PR DESCRIPTION
The Rust-based svdtools patch help output suggests that the user provides an SVD file:

```
  $ svdtools patch --help
  svdtools-patch
  Patches an SVD file as specified by a YAML file

  USAGE:
      svdtools patch <SVD_FILE>

  ARGS:
      <SVD_FILE>    Path to input SVD file

  OPTIONS:
      -h, --help    Print help information
```

If we actually provide an SVD file, the tool errors.

Compare this with the Python documentation, which suggests that the user
provides a YAML file, not an SVD file.

```
  $ svd patch --help
  Usage: svd patch [OPTIONS] YAML_FILE

    Patches an SVD file as specified by a YAML file

  Options:
    --help  Show this message and exit.
```