### PR TITLE
Fix UnboundLocalError in patch.py

### DIFF
--- a/svdtools/patch.py
+++ b/svdtools/patch.py
@@ -852,7 +852,7 @@ class Peripheral:
         elif isinstance(rmod, dict):
             rderive = rmod["_from"]
             address_offset = rmod.get("addressOffset", None)
-            description = rmod.get(description, None)
+            description = rmod.get("description", None)
         else:
             raise SvdPatchError(f"derive: incorrect syntax for {rname}")
         rtag = parent.find(f"./register[name='{rname}']")


### PR DESCRIPTION
Fixes this error message:
```
File "/home/jan/.local/lib/python3.7/site-packages/svdtools/patch.py", line 855, in derive_register
    description = rmod.get(description, None)
UnboundLocalError: local variable 'description' referenced before assignment
```