### PR TITLE
small type inference fix

### DIFF
--- a/src/html/html_cli.rs
+++ b/src/html/html_cli.rs
@@ -400,7 +400,7 @@ fn parse_register(
         }
     }
     let table = vec![
-        (filling > u16::MAX as _)
+        (filling > u16::MAX as u64)
             .then(|| object!({"headers": (16..32).rev().collect::<Vec<_>>(), "fields": table[0]})),
         (filling > 0)
             .then(|| object!({"headers": (0..16).rev().collect::<Vec<_>>(), "fields": table[1]})),


### PR DESCRIPTION
I experimented with https://github.com/pftbest/msp430_svd today, and got this compile error:

```sh
svdtools on  master [$] is 📦 v0.4.5 via 🐍 v3.12.3 via 🦀 v1.85.0
❯ cargo check
    Checking svdtools v0.4.5 (/home/rmueller/Rust/svdtools)
error[E0282]: type annotations needed
   --> src/html/html_cli.rs:403:32
    |
403 |         (filling > u16::MAX as _)
    |                                ^ cannot infer type

For more information about this error, try `rustc --explain E0282`.
error: could not compile `svdtools` (lib) due to 1 previous error

```